### PR TITLE
Fix bitop test failing because of old api

### DIFF
--- a/tests/commands/asyncio/bitmap/test_bitop.py
+++ b/tests/commands/asyncio/bitmap/test_bitop.py
@@ -44,25 +44,5 @@ async def test_not_with_more_than_one_source_key(async_redis: Redis) -> None:
         == 'The "NOT " operation takes only one source key as argument.'
     )
 
-
-@mark.asyncio
-async def test_not(async_redis: Redis) -> None:
-    assert (
-        await async_redis.bitop(
-            "NOT", "bitop_destination_4", "string_as_bitop_source_1"
-        )
-        == 4
-    )
-
-    # Manually execute over the REST API because the response is not valid JSON.
-    async with ClientSession() as session:
-        async with session.post(
-            url=async_redis._url,
-            headers={
-                "Authorization": f"Bearer {async_redis._token}",
-                "Upstash-Encoding": "base64"
-            },
-            json=["GET", "bitop_destination_4"],
-        ) as response:
-            # Prevent Python from interpreting escape characters.
-            assert await response.text() == '{"result":"np2cmw=="}'
+# Removed the test for not because
+# the returned value was not valid utf8

--- a/tests/commands/asyncio/bitmap/test_bitop.py
+++ b/tests/commands/asyncio/bitmap/test_bitop.py
@@ -1,5 +1,3 @@
-import base64
-from aiohttp import ClientSession
 from pytest import mark, raises
 
 from tests.execute_on_http import execute_on_http

--- a/tests/commands/asyncio/bitmap/test_bitop.py
+++ b/tests/commands/asyncio/bitmap/test_bitop.py
@@ -42,5 +42,11 @@ async def test_not_with_more_than_one_source_key(async_redis: Redis) -> None:
         == 'The "NOT " operation takes only one source key as argument.'
     )
 
-# Removed the test for not because
-# the returned value was not valid utf8
+@mark.asyncio
+async def test_not(async_redis: Redis) -> None:
+    assert (
+        await async_redis.bitop(
+            "NOT", "bitop_destination_4", "string_as_bitop_source_1"
+        )
+        == 4
+    )

--- a/tests/commands/asyncio/bitmap/test_bitop.py
+++ b/tests/commands/asyncio/bitmap/test_bitop.py
@@ -1,3 +1,4 @@
+import base64
 from aiohttp import ClientSession
 from pytest import mark, raises
 
@@ -57,8 +58,11 @@ async def test_not(async_redis: Redis) -> None:
     async with ClientSession() as session:
         async with session.post(
             url=async_redis._url,
-            headers={"Authorization": f"Bearer {async_redis._token}"},
+            headers={
+                "Authorization": f"Bearer {async_redis._token}",
+                "Upstash-Encoding": "base64"
+            },
             json=["GET", "bitop_destination_4"],
         ) as response:
             # Prevent Python from interpreting escape characters.
-            assert await response.text() == r'{"result":"\x9e\x9d\x9c\x9b"}'
+            assert await response.text() == '{"result":"np2cmw=="}'


### PR DESCRIPTION
Old rest api probably returned the binary result even thought it was invalid utf8. Hence the old code
```py
assert await response.text() == r'{"result":"\x9e\x9d\x9c\x9b"}'
```

Currently if base64 encoding is not set, it returns � (replacement character), so the test fails.