### PR TITLE
Fix set command with the get option not returning result

### DIFF
--- a/tests/commands/string/test_set.py
+++ b/tests/commands/string/test_set.py
@@ -22,6 +22,19 @@ def test_set(redis: Redis):
     assert redis.get(key) == value
     assert redis.ttl(key) == ex_seconds
 
+def test_set_with_get(redis: Redis):
+    key = "mykey"
+    value = "myvalue"
+    ex_seconds = 10
+
+    redis.set(key, value)
+
+    result = redis.set(key, value, ex=ex_seconds, get=True)
+
+    assert result == value
+    assert redis.get(key) == value
+    assert redis.ttl(key) == ex_seconds
+
 
 def test_set_invalid_parameters(redis: Redis):
     key = "mykey"

--- a/tests/commands/string/test_set.py
+++ b/tests/commands/string/test_set.py
@@ -24,16 +24,15 @@ def test_set(redis: Redis):
 
 def test_set_with_get(redis: Redis):
     key = "mykey"
+    old_value = "myvalue"
     value = "myvalue"
-    ex_seconds = 10
 
-    redis.set(key, value)
+    redis.set(key, old_value)
 
-    result = redis.set(key, value, ex=ex_seconds, get=True)
+    result = redis.set(key, value, get=True)
 
-    assert result == value
+    assert result == old_value
     assert redis.get(key) == value
-    assert redis.ttl(key) == ex_seconds
 
 
 def test_set_invalid_parameters(redis: Redis):

--- a/tests/commands/string/test_set.py
+++ b/tests/commands/string/test_set.py
@@ -24,8 +24,8 @@ def test_set(redis: Redis):
 
 def test_set_with_get(redis: Redis):
     key = "mykey"
-    old_value = "myvalue"
-    value = "myvalue"
+    old_value = "old-value"
+    value = "new-value"
 
     redis.set(key, old_value)
 

--- a/upstash_redis/format.py
+++ b/upstash_redis/format.py
@@ -128,6 +128,12 @@ def format_float_list(
 
     return [float(value) if value is not None else None for value in raw]
 
+def set_formatter(res, command):
+    options = command[3:]
+
+    if "GET" in options:
+        return res
+    return res == "OK"
 
 def to_set(res, command):
     return set(res)
@@ -316,7 +322,7 @@ FORMATTERS: Dict[str, Callable] = {
     "FLUSHALL": ok_to_bool,
     "FLUSHDB": ok_to_bool,
     "PSETEX": ok_to_bool,
-    "SET": ok_to_bool,
+    "SET": set_formatter,
     "SETEX": ok_to_bool,
     "SETNX": to_bool,
     "MSET": ok_to_bool,


### PR DESCRIPTION
```py
# Returns `True` instead of the old value
redis.set("key", "val", get=True)
```